### PR TITLE
Update LibraryBuild.yml

### DIFF
--- a/.github/workflows/LibraryBuild.yml
+++ b/.github/workflows/LibraryBuild.yml
@@ -56,7 +56,7 @@ jobs:
             platform-url: https://raw.githubusercontent.com/ArminJo/DigistumpArduino/master/package_digistump_index.json
 
 #          - arduino-boards-fqbn: ATTinyCore:avr:attinyx5:chip=85,clock=1internal
-#            platform-url: http://drazzy.com/package_drazzy.com_index.json
+#            platform-url: https://drazzy.good-enough.cloud/package_drazzy.com_index.json
 
       # Do not cancel all jobs / architectures if one job fails
       fail-fast: true


### PR DESCRIPTION
Updates platform-url to use [the same one used by Adafruit](https://github.com/adafruit/ci-arduino/blob/master/build_platform.py#L72) (though this does not resolve the issue of the micronucleus toolchain being hosted on Azduino and thus subject to the same SSL cert issues).

This only affects the github runner and is commented out anyway, so won't affect versioning of this library.